### PR TITLE
Adding Python3 support for yolk functions that access pypi

### DIFF
--- a/yolk/pypi.py
+++ b/yolk/pypi.py
@@ -203,13 +203,19 @@ class CheeseShop(object):
         """Return list of pickled package names from PYPI"""
         if self.debug:
             self.logger.debug("DEBUG: reading pickled cache file")
-        return cPickle.load(open(self.pkg_cache_file, "rb"))
+        if platform.python_version().startswith('2'):
+            return cPickle.load(open(self.pkg_cache_file, "r"))
+        else:
+            return cPickle.load(open(self.pkg_cache_file, "rb"))
 
     def fetch_pkg_list(self):
         """Fetch and cache master list of package names from PYPI"""
         self.logger.debug("DEBUG: Fetching package name list from PyPI")
         package_list = self.list_packages()
-        cPickle.dump(package_list, open(self.pkg_cache_file, "wb"))
+        if platform.python_version().startswith('2'):
+            cPickle.dump(package_list, open(self.pkg_cache_file, "w"))
+        else:
+            cPickle.dump(package_list, open(self.pkg_cache_file, "wb"))
         self.pkg_list = package_list
 
     def search(self, spec, operator):

--- a/yolk/pypi.py
+++ b/yolk/pypi.py
@@ -203,19 +203,24 @@ class CheeseShop(object):
         """Return list of pickled package names from PYPI"""
         if self.debug:
             self.logger.debug("DEBUG: reading pickled cache file")
-        if platform.python_version().startswith('2'):
-            return cPickle.load(open(self.pkg_cache_file, "r"))
-        else:
+        try:
             return cPickle.load(open(self.pkg_cache_file, "rb"))
+        except ValueError:
+            return cPickle.load(open(self.pkg_cache_file, "r"))
+        # if platform.python_version().startswith('2'):
+        #     return cPickle.load(open(self.pkg_cache_file, "r"))
+        # else:
+        #     return cPickle.load(open(self.pkg_cache_file, "rb"))
 
     def fetch_pkg_list(self):
         """Fetch and cache master list of package names from PYPI"""
         self.logger.debug("DEBUG: Fetching package name list from PyPI")
         package_list = self.list_packages()
-        if platform.python_version().startswith('2'):
-            cPickle.dump(package_list, open(self.pkg_cache_file, "w"))
-        else:
-            cPickle.dump(package_list, open(self.pkg_cache_file, "wb"))
+        cPickle.dump(package_list, open(self.pkg_cache_file, "wb"))
+        # if platform.python_version().startswith('2'):
+        #     cPickle.dump(package_list, open(self.pkg_cache_file, "w"))
+        # else:
+        #     cPickle.dump(package_list, open(self.pkg_cache_file, "wb"))
         self.pkg_list = package_list
 
     def search(self, spec, operator):

--- a/yolk/pypi.py
+++ b/yolk/pypi.py
@@ -164,7 +164,7 @@ class CheeseShop(object):
         Returns PyPI's XML-RPC server instance
         """
         check_proxy_setting()
-        if os.environ.has_key('XMLRPC_DEBUG'):
+        if 'XMLRPC_DEBUG' in os.environ:
             debug = 1
         else:
             debug = 0
@@ -275,7 +275,7 @@ class CheeseShop(object):
 
             #Try the package's metadata directly in case there's nothing
             #returned by XML-RPC's release_urls()
-            if metadata and metadata.has_key('download_url') and \
+            if metadata and 'download_url' in metadata and \
                         metadata['download_url'] != "UNKNOWN" and \
                         metadata['download_url'] != None:
                 if metadata['download_url'] not in all_urls:

--- a/yolk/pypi.py
+++ b/yolk/pypi.py
@@ -24,7 +24,7 @@ if platform.python_version().startswith('2'):
     import urllib2
 else:
     import xmlrpc.client as xmlrpclib
-    import pickle
+    import pickle as cPickle
     import urllib.request as urllib2
 import os
 import time

--- a/yolk/pypi.py
+++ b/yolk/pypi.py
@@ -203,13 +203,13 @@ class CheeseShop(object):
         """Return list of pickled package names from PYPI"""
         if self.debug:
             self.logger.debug("DEBUG: reading pickled cache file")
-        return cPickle.load(open(self.pkg_cache_file, "r"))
+        return cPickle.load(open(self.pkg_cache_file, "rb"))
 
     def fetch_pkg_list(self):
         """Fetch and cache master list of package names from PYPI"""
         self.logger.debug("DEBUG: Fetching package name list from PyPI")
         package_list = self.list_packages()
-        cPickle.dump(package_list, open(self.pkg_cache_file, "w"))
+        cPickle.dump(package_list, open(self.pkg_cache_file, "wb"))
         self.pkg_list = package_list
 
     def search(self, spec, operator):

--- a/yolk/pypi.py
+++ b/yolk/pypi.py
@@ -207,20 +207,12 @@ class CheeseShop(object):
             return cPickle.load(open(self.pkg_cache_file, "rb"))
         except ValueError:
             return cPickle.load(open(self.pkg_cache_file, "r"))
-        # if platform.python_version().startswith('2'):
-        #     return cPickle.load(open(self.pkg_cache_file, "r"))
-        # else:
-        #     return cPickle.load(open(self.pkg_cache_file, "rb"))
 
     def fetch_pkg_list(self):
         """Fetch and cache master list of package names from PYPI"""
         self.logger.debug("DEBUG: Fetching package name list from PyPI")
         package_list = self.list_packages()
         cPickle.dump(package_list, open(self.pkg_cache_file, "wb"))
-        # if platform.python_version().startswith('2'):
-        #     cPickle.dump(package_list, open(self.pkg_cache_file, "w"))
-        # else:
-        #     cPickle.dump(package_list, open(self.pkg_cache_file, "wb"))
         self.pkg_list = package_list
 
     def search(self, spec, operator):


### PR DESCRIPTION
Also invisibly changing the format of the pkg_list.pkl cache file from str to bytes, which works with Python2 while allowing Python3 compatibility
