### PR TITLE
Try file 'PKG-INFO' or 'METADATA' to retrieve package metadata

### DIFF
--- a/yolk/metadata.py
+++ b/yolk/metadata.py
@@ -32,10 +32,14 @@ def get_metadata(dist):
     @returns: dict of metadata or None
 
     """
-    if not dist.has_metadata('PKG-INFO'):
+    if dist.has_metadata('PKG-INFO'):
+        metadata = dist.get_metadata('PKG-INFO')
+    elif dist.has_metadata('METADATA'):
+        metadata = dist.get_metadata('METADATA')
+    else:
         return
 
-    msg = email.message_from_string(dist.get_metadata('PKG-INFO'))
+    msg = email.message_from_string(metadata)
     metadata = {}
     for header in [l for l in msg._headers]:
         metadata[header[0]] = header[1]


### PR DESCRIPTION
Some packages seem to store the metadata in a file called 'METADATA' instead
of 'PKG-INFO'. Probably the change is related to a newer pip or setuptools
version but I don't know for sure.
