### PR TITLE
pypi.py: Use HTTPS for PyPi.

### DIFF
--- a/yolk/pypi.py
+++ b/yolk/pypi.py
@@ -80,7 +80,7 @@ class ProxyTransport(xmlrpclib.Transport):
         '''Send xml-rpc request using proxy'''
         #We get a traceback if we don't have this attribute:
         self.verbose = verbose
-        url = 'http://' + host + handler
+        url = 'https://' + host + handler
         request = urllib2.Request(url)
         request.add_data(request_body)
         # Note: 'Host' and 'Content-Length' are added automatically


### PR DESCRIPTION
PyPi now requires HTTPS after CVE-2016-5699.

http://blog.blindspotsecurity.com/2016/06/advisory-http-header-injection-in.html

This patch fixes this error on Fedora.

$ yolk --version
Traceback (most recent call last):
  File "/usr/bin/yolk", line 9, in <module>
    load_entry_point('yolk==0.4.3', 'console_scripts', 'yolk')()
  File "/usr/lib/python2.7/site-packages/yolk/cli.py", line 1090, in main
    my_yolk.run()
  File "/usr/lib/python2.7/site-packages/yolk/cli.py", line 180, in run
    self.pypi = CheeseShop(self.options.debug)
  File "/usr/lib/python2.7/site-packages/yolk/pypi.py", line 109, in **init**
    self.get_cache()
  File "/usr/lib/python2.7/site-packages/yolk/pypi.py", line 127, in get_cache
    self.fetch_pkg_list()
  File "/usr/lib/python2.7/site-packages/yolk/pypi.py", line 184, in fetch_pkg_list
    package_list = self.list_packages()
  File "/usr/lib/python2.7/site-packages/yolk/pypi.py", line 202, in list_packages
    return self.xmlrpc.list_packages()
  File "/usr/lib64/python2.7/xmlrpclib.py", line 1240, in **call**
    return self.__send(self.__name, args)
  File "/usr/lib64/python2.7/xmlrpclib.py", line 1599, in __request
    verbose=self.__verbose
  File "/usr/lib/python2.7/site-packages/yolk/pypi.py", line 64, in request
    fhandle = opener.open(request)
  File "/usr/lib64/python2.7/urllib2.py", line 437, in open
    response = meth(req, response)
  File "/usr/lib64/python2.7/urllib2.py", line 550, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/lib64/python2.7/urllib2.py", line 475, in error
    return self._call_chain(_args)
  File "/usr/lib64/python2.7/urllib2.py", line 409, in _call_chain
    result = func(_args)
  File "/usr/lib64/python2.7/urllib2.py", line 558, in http_error_default
    raise HTTPError(req.get_full_url(), code, msg, hdrs, fp)
urllib2.HTTPError: HTTP Error 403: Must access using HTTPS instead of HTTP

Signed-off-by: Vinson Lee vlee@freedesktop.org
